### PR TITLE
Adding an option to exclude paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Default: `999`
 
 Limit of iterations.
 
+###### options.exclude
+Type: `Array`  
+Default: `[]`
+
+Contains a list of "excluded" filepaths that will not be returned by the module in any case.
 
 ## License
 

--- a/lib/salvator.js
+++ b/lib/salvator.js
@@ -37,7 +37,7 @@ function template(str) {
             return data[key];
         });
     };
-};
+}
 
 function getBump(filepath, format) {
     var dirname, filename, extname, tpl;
@@ -84,7 +84,8 @@ module.exports = function(filepath, options) {
                     return next(new Error("Limit exceeded"));
                 }
 
-                fs.exists(filepath, function(exists) {
+                fs.stat(filepath, function (err) {
+                    var exists = !err;
                     next(null, exists);
                 });
             },

--- a/lib/salvator.js
+++ b/lib/salvator.js
@@ -63,7 +63,7 @@ function getBump(filepath, format) {
 }
 
 module.exports = function(filepath, options) {
-    var counter, format, limit, bump;
+    var counter, format, limit, exclude, bump;
 
     assert(typeof filepath == "string", "String is expected");
 
@@ -71,6 +71,7 @@ module.exports = function(filepath, options) {
     counter = options.counter || function(fix) {  return fix == void 0 ? 1 : ++fix; };
     format  = options.format || "${dirname}/${filename}(${fix}).${extname}";
     limit   = options.limit || 999;
+    exclude = options.exclude || [];
 
     bump = getBump(filepath, format);
 
@@ -85,8 +86,9 @@ module.exports = function(filepath, options) {
                 }
 
                 fs.stat(filepath, function (err) {
-                    var exists = !err;
-                    next(null, exists);
+                    var exists = !err,
+                        excluded = exclude.indexOf(filepath) !== -1;
+                    next(null, exists || excluded);
                 });
             },
             // iterator

--- a/lib/salvator.js
+++ b/lib/salvator.js
@@ -85,10 +85,13 @@ module.exports = function(filepath, options) {
                     return next(new Error("Limit exceeded"));
                 }
 
+                if (exclude.indexOf(filepath) !== -1) {
+                    return next(null, true);
+                }
+
                 fs.stat(filepath, function (err) {
-                    var exists = !err,
-                        excluded = exclude.indexOf(filepath) !== -1;
-                    next(null, exists || excluded);
+                    var exists = !err;
+                    next(null, exists);
                 });
             },
             // iterator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salvator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "engines" : { "node" : ">=0.12.0" },
   "description": "Safe write path checker",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salvator",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "engines" : { "node" : ">=0.12.0" },
   "description": "Safe write path checker",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salvator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines" : { "node" : ">=0.12.0" },
   "description": "Safe write path checker",
   "author": {

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,7 @@ describe('salvator', function () {
 
 	it('should return promise', function() {
 		// prepare
-		fs.exists = function noop(){};
+		fs.stat = function noop(){};
 
 		// when
 		var result = salvator('aaa');
@@ -31,18 +31,18 @@ describe('salvator', function () {
 	});
 
 	it('should check existance of file', function (done) {
-		var path, initialPath, count, exists;
+		var path, initialPath, count, stat;
 
 		// before
 		count = 0;
 
-		fs.exists = (exists = sinon.spy(function(path, callback) {
+		fs.stat = (stat = sinon.spy(function(path, callback) {
 			if (count == 2) {
-				return callback(false);
+				return callback(true);
 			}
 
 			count++;
-			callback(true);
+			callback(false);
 		}));
 
 		// when
@@ -56,8 +56,8 @@ describe('salvator', function () {
 		// then
 		path
 			.then(function(result) {
-				expect(exists.callCount).equal(3);
-				// expect(exists.calledWithExactly(initialPath)).to.be.true;
+				expect(stat.callCount).equal(3);
+				// expect(stat.calledWithExactly(initialPath)).to.be.true;
 				expect(result).equal("/path/to/abc(2).js");
 			})
 			.then(done, done);


### PR DESCRIPTION
First of all, thanks for sharing this module !

I'm copying several files (that can have the same name) to a target directory, I'm using salvator to get a "safe" filepath for each of them. Since the copy operation is async, the n<sup>th</sup> file may not exist when the n+1<sup>th</sup> file is copied so I needed to mimic its existence.

That is why I added an `exclude` option to define filepaths that would not be returned by the module in any case. I'm submitting this PR if you want to merge it.
